### PR TITLE
Voeg informatie toe over globale .gitignore

### DIFF
--- a/project_architecture/README.md
+++ b/project_architecture/README.md
@@ -31,3 +31,15 @@ Zoals in de Jenkinsfile gedefinieerd hanteren we de volgende deployment strategi
 - Alle pushes naar `master` deployen we naar acceptatie.
 - Alle tags die aan het semver formaat voldoen (x.y.z*) deployen we naar productie.
 Jenkins scant periodiek de repository en deployed automatisch.
+
+## gitignore
+
+Het is aan te raden om een global .gitignore bestand in te stellen zodat bijvoorbeeld de gekopieerde `docker-compose.override.yml` bestand door git genegeerd wordt, bivoorbeeld...
+
+```gitignore
+# ~/.gitignore
+docker-compose.override.yml
+.idea/
+.env
+.python-version
+```

--- a/project_architecture/README.md
+++ b/project_architecture/README.md
@@ -34,7 +34,7 @@ Jenkins scant periodiek de repository en deployed automatisch.
 
 ## gitignore
 
-Het is aan te raden om een global .gitignore bestand in te stellen zodat bijvoorbeeld de gekopieerde `docker-compose.override.yml` bestand door git genegeerd wordt, bivoorbeeld...
+Het is aan te raden om een global .gitignore bestand in te stellen zodat bijvoorbeeld het gekopieerde `docker-compose.override.yml` bestand door git genegeerd wordt, bijvoorbeeld...
 
 ```gitignore
 # ~/.gitignore


### PR DESCRIPTION
Als onderdeel van de werkwijze van de opdrachten team wordt er over het algemeen met een globale `.gitignore` gewerkt. Dit zorgt ervoor dat bijvoorbeeld overal de `docker-compose.override.yml` niet genegeerd hoeft te worden. Lijkt mij handig om dit expliciet te noemen in deze gids.